### PR TITLE
ignore ShardId,HashKey,PartitionKey if empty

### DIFF
--- a/datahub/models/record.go
+++ b/datahub/models/record.go
@@ -64,9 +64,9 @@ func (rs *RecordSchema) Size() int {
 
 // BaseRecord
 type BaseRecord struct {
-	ShardId      string            `json:"ShardId"`
-	HashKey      string            `json:"HashKey"`
-	PartitionKey string            `json:"PartitionKey"`
+	ShardId      string            `json:"ShardId,omitempty"`
+	HashKey      string            `json:"HashKey,omitempty"`
+	PartitionKey string            `json:"PartitionKey,omitempty"`
 	Attributes   map[string]string `json:"Attributes"`
 }
 


### PR DESCRIPTION
应该允许ShardId,HashKey或者PartitionKey为空，否则当ShardId为空时，返回错误:

> errorCode:InvalidShardId,errorMsg:Invalid shard id :